### PR TITLE
Restaura web: burgers disponibles, orden original, recomendada del miercoles

### DIFF
--- a/src/data/menu.js
+++ b/src/data/menu.js
@@ -40,7 +40,7 @@ export const burgers = [
       { id: "caramelized_onion", label: "Cebolla caramelizada" },
     ],
     img: "/burgers/lautiboom.svg",
-    isAvailable: 0,
+    isAvailable: 1,
   },
   {
     id: "american",
@@ -57,7 +57,7 @@ export const burgers = [
       { id: "mil_islas", label: "Salsa Mil Islas" },
     ],
     img: "/burgers/american.svg",
-    isAvailable: 0,
+    isAvailable: 1,
   },
   {
     id: "bacon",
@@ -88,7 +88,7 @@ export const burgers = [
       { id: "caramelized_onion", label: "Cebolla caramelizada" },
     ],
     img: "/burgers/bbqueen.svg",
-    isAvailable: 0,
+    isAvailable: 1,
   },
   {
     id: "smoklahoma",

--- a/src/pages/Burgers/Burgers.jsx
+++ b/src/pages/Burgers/Burgers.jsx
@@ -44,16 +44,6 @@ const SHOWCASE_SECTIONS = [
     ],
   },
   {
-    id: "deluxe",
-    title: "Burgers deluxe",
-    subtitle: "Sabor de lujo.",
-    tone: "deluxe",
-    layout: "single",
-    items: [
-      { id: "smoklahoma", emphasis: "deluxe" },
-    ],
-  },
-  {
     id: "rompen",
     title: "Las que la rompen",
     subtitle: "Mas premium, mas ingredientes.",
@@ -65,13 +55,14 @@ const SHOWCASE_SECTIONS = [
     ],
   },
   {
-    id: "deluxe2",
-    title: "",
-    subtitle: "",
+    id: "deluxe",
+    title: "Burgers deluxe",
+    subtitle: "Sabor de lujo.",
     tone: "deluxe",
-    layout: "single",
+    layout: "pair",
     items: [
       { id: "bbqueen", emphasis: "deluxe" },
+      { id: "smoklahoma", emphasis: "deluxe" },
     ],
   },
   {
@@ -222,12 +213,10 @@ export default function Burgers() {
         <section
           key={section.id}
           className={`${styles.section} ${SECTION_CLASS[section.tone] || ""}`}>
-          {section.title && (
-            <div className={styles.sectionHeader}>
-              <h2 className={styles.sectionTitle}>{section.title}</h2>
-              <p className={styles.sectionSubtitle}>{section.subtitle}</p>
-            </div>
-          )}
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>{section.title}</h2>
+            <p className={styles.sectionSubtitle}>{section.subtitle}</p>
+          </div>
 
           <div className={`${styles.cards} ${LAYOUT_CLASS[section.layout] || ""}`}>
             {section.items.map((entry, itemIndex) => {

--- a/src/pages/Menu/Menu.jsx
+++ b/src/pages/Menu/Menu.jsx
@@ -61,10 +61,10 @@ function ChevronBtn({ dir, disabled, onClick }) {
 const BURGER_ROWS = [
   { id: "cheese", emphasis: "top", badge: "TOP" },
   { id: "bacon", emphasis: "top", badge: "TOP" },
-  { id: "smoklahoma", emphasis: "deluxe" },
   { id: "lautiboom", emphasis: "mid" },
   { id: "american", emphasis: "mid" },
   { id: "bbqueen", emphasis: "deluxe" },
+  { id: "smoklahoma", emphasis: "deluxe" },
 ];
 
 export default function Menu() {

--- a/src/utils/dailyFeaturePromo.js
+++ b/src/utils/dailyFeaturePromo.js
@@ -2,10 +2,10 @@ import { getArgentinaTimeParts } from "./storeClosedMode";
 
 // Override manual: si querés forzar otra burger un día puntual,
 // poné el id acá (ej: "bacon"). null = usar el mapping automático por día.
-export const DAILY_FEATURE_OVERRIDE_ID = "cheese";
+export const DAILY_FEATURE_OVERRIDE_ID = null;
 
 // Texto del eyebrow cuando usás override manual. null = muestra "RECOMENDADA DEL <DÍA>" normal.
-export const DAILY_FEATURE_OVERRIDE_LABEL = "PROMO MEDIODIA";
+export const DAILY_FEATURE_OVERRIDE_LABEL = null;
 
 // Fallback de stock: cuando se agota la burger del día, poné el id acá (ej: "cheese").
 // null = sin fallback, se muestra la burger del día normal.


### PR DESCRIPTION
Habilita todas las burgers, restaura el orden original de secciones y vuelve a la recomendada del miércoles (American) sin el override de promo mediodia.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DehHhTAbeqBoyt1WwFhMFY)_