### PR TITLE
Ordena burgers no disponibles al final del carrusel en Menu

### DIFF
--- a/src/pages/Menu/Menu.jsx
+++ b/src/pages/Menu/Menu.jsx
@@ -118,7 +118,13 @@ export default function Menu() {
         const burger = burgersById[entry.id];
         if (!burger) return null;
         return { ...entry, burger };
-      }).filter(Boolean),
+      })
+      .filter(Boolean)
+      .sort((a, b) => {
+        const aUnavail = isItemUnavailable(a.burger) ? 1 : 0;
+        const bUnavail = isItemUnavailable(b.burger) ? 1 : 0;
+        return aUnavail - bUnavail;
+      }),
     [burgersById],
   );
 


### PR DESCRIPTION
Las burgers no disponibles se muestran automáticamente al final del carrusel en la página de Menú.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DehHhTAbeqBoyt1WwFhMFY)_